### PR TITLE
Fixed minor build warnings

### DIFF
--- a/src/wrappers/eof.cpp
+++ b/src/wrappers/eof.cpp
@@ -1055,7 +1055,7 @@ extern "C" int eofunc_north(
       printf("index    dlam      low       pcvar     high    sig_pcv\n");
       for (size_t i = 0; i < neval; ++i) {
         printf(
-          "(%2d)    %7.5f   %7.5f   %7.5f   %7.5f  %s\n",
+          "(%2zd)    %7.5f   %7.5f   %7.5f   %7.5f  %s\n",
           i,
           dlam[i], low[i], eval_d[i], high[i],
           sig_value[i] == 1 ? "True" : "False"

--- a/test/test_eofunc_north_01.c
+++ b/test/test_eofunc_north_01.c
@@ -41,8 +41,8 @@ int main(void) {
   for (int i = 0; i < 4; ++i) {
     if (((int*) ncomp_sig_out->addr)[i] != expected_sig_out[i]) {
       printf("problem with ncomp_sig_out->addr\n");
-      printf("Expected: ncomp_sig_out[%d] = %f\n", i, expected_sig_out[i]);
-      printf("  Actual: ncomp_sig_out[%d] = %f\n", i, ((int*) ncomp_sig_out->addr)[i]);
+      printf("Expected: ncomp_sig_out[%d] = %d\n", i, expected_sig_out[i]);
+      printf("  Actual: ncomp_sig_out[%d] = %d\n", i, ((int*) ncomp_sig_out->addr)[i]);
       return 3;
     }
   }

--- a/test/test_eofunc_north_02.c
+++ b/test/test_eofunc_north_02.c
@@ -41,8 +41,8 @@ int main(void) {
   for (int i = 0; i < 4; ++i) {
     if (((int*) ncomp_sig_out->addr)[i] != expected_sig_out[i]) {
       printf("problem with ncomp_sig_out->addr\n");
-      printf("Expected: ncomp_sig_out[%d] = %f\n", i, expected_sig_out[i]);
-      printf("  Actual: ncomp_sig_out[%d] = %f\n", i, ((int*) ncomp_sig_out->addr)[i]);
+      printf("Expected: ncomp_sig_out[%d] = %d\n", i, expected_sig_out[i]);
+      printf("  Actual: ncomp_sig_out[%d] = %d\n", i, ((int*) ncomp_sig_out->addr)[i]);
       return 3;
     }
   }


### PR DESCRIPTION
All of the warnings were related to mismatched printf formats and variable types, nothing serious.

It looks like warning messages on CircleCI are being redirected to /dev/null, but I'll look into that issue separately.