### PR TITLE
Use ncomp_array** for output arrays

### DIFF
--- a/src/ncomp/wrapper.h
+++ b/src/ncomp/wrapper.h
@@ -20,25 +20,25 @@ int rgrid2rcm(const ncomp_array *lat1d, const ncomp_array *lon1d,
 
 int eofunc(const ncomp_array * x_in, const int neval_in,
            const ncomp_attributes * options_in,
-           ncomp_array * x_out, ncomp_attributes * attrList_out);
+           ncomp_array ** x_out, ncomp_attributes * attrList_out);
 
 int eofunc_n(const ncomp_array * x_in, const int neval_in,
              const int t_dim,
              const ncomp_attributes * options_in,
-             ncomp_array * x_out, ncomp_attributes * attrList_out);
+             ncomp_array ** x_out, ncomp_attributes * attrList_out);
 
 int eofunc_north(
   const ncomp_array * eval,
   int N,
   int prinfo,
-  ncomp_array * sig,
+  ncomp_array ** sig,
   ncomp_attributes * out_attrs);
 
 int eofunc_ts(
   const ncomp_array * x_in,
   const ncomp_array * evec_in,
   const ncomp_attributes * options_in,
-  ncomp_array * x_out,
+  ncomp_array ** x_out,
   ncomp_attributes * attrs_out);
 
 int eofunc_ts_n(
@@ -46,12 +46,12 @@ int eofunc_ts_n(
     const ncomp_array * evec_in,
     const ncomp_attributes * options_in,
     const int t_dim,
-    ncomp_array * x_out,
+    ncomp_array ** x_out,
     ncomp_attributes * attrs_out);
 
 int moc_globe_atl( const ncomp_array *, const ncomp_array *, const ncomp_array *,
                    const ncomp_array *, const ncomp_array *, const ncomp_array *,
-                   ncomp_array * );
+                   ncomp_array ** );
 
 #ifdef __cplusplus /* If this is a C++ compiler, end C linkage */
 }

--- a/src/wrappers/eof.cpp
+++ b/src/wrappers/eof.cpp
@@ -159,7 +159,7 @@ eofunc_options* extract_eofunc_options(const ncomp_attributes * options_in) {
 
 extern "C" int eofunc(const ncomp_array * x_in, const int neval_in,
                       const ncomp_attributes * options_in,
-                      ncomp_array * x_out, ncomp_attributes * attrList_out) {
+                      ncomp_array ** x_out, ncomp_attributes * attrList_out) {
   int i_error = 0;
 
   // Sanity Checking
@@ -668,9 +668,9 @@ extern "C" int eofunc(const ncomp_array * x_in, const int neval_in,
      * Set up return value.
      */
      // x_out is the return_md in NCL code.
-     *x_out = *ncomp_array_alloc((void *) revec.release(), NCOMP_FLOAT, x_in->ndim, dsizes_evec.get());
-     x_out->has_missing = x_in->has_missing;
-     x_out->msg.msg_float = missing_f_x_in;
+     *x_out = ncomp_array_alloc((void *) revec.release(), NCOMP_FLOAT, x_in->ndim, dsizes_evec.get());
+     (*x_out)->has_missing = x_in->has_missing;
+     (*x_out)->msg.msg_float = missing_f_x_in;
 
     /*
      * Only return the eigenvalues if the appropriate option has been set.
@@ -736,9 +736,9 @@ extern "C" int eofunc(const ncomp_array * x_in, const int neval_in,
      *  Return doubles.
      */
 
-    *x_out = *ncomp_array_alloc((void *) evec.release(), NCOMP_DOUBLE, x_in->ndim, dsizes_evec.get());
-    x_out->has_missing = x_in->has_missing;
-    x_out->msg.msg_double = missing_d_x_in;
+    *x_out = ncomp_array_alloc((void *) evec.release(), NCOMP_DOUBLE, x_in->ndim, dsizes_evec.get());
+    (*x_out)->has_missing = x_in->has_missing;
+    (*x_out)->msg.msg_double = missing_d_x_in;
 
     /*
      * Only return the eigenvalues if the appropriate option has been set.
@@ -950,7 +950,7 @@ ncomp_array * _rearrange_ncomp_array(
 extern "C" int eofunc_n(const ncomp_array * x_in, const int neval_in,
                         const int t_dim,
                         const ncomp_attributes * options_in,
-                        ncomp_array * x_out, ncomp_attributes * attrList_out) {
+                        ncomp_array ** x_out, ncomp_attributes * attrList_out) {
   // Sanity Checking
   // Although this check is also performed when eofunc is called, but let's
   // terminate early, if we have too and not bother with rearranging at all.
@@ -980,7 +980,7 @@ extern "C" int eofunc_north(
   const ncomp_array * eval,
   int N,
   int prinfo,
-  ncomp_array * sig,
+  ncomp_array ** sig,
   ncomp_attributes * out_attrs) {
   // ORIGINAL COMMENTS FROM CONTRIBUTED.NCL (DOESN"T NECESSARILLY APPLY HERE)
   // North, G.R. et al (1982): Sampling Errors in the Estimation of Empirical Orthogonal Functions.
@@ -1011,7 +1011,7 @@ extern "C" int eofunc_north(
       create_ncomp_single_attribute_char((char *) "long_name", (char *) "EOF separation is not testable N=1")
     );
 
-    *sig = *ncomp_array_alloc_scalar(static_cast<void *>(sig_value), NCOMP_BOOL);
+    *sig = ncomp_array_alloc_scalar(static_cast<void *>(sig_value), NCOMP_BOOL);
 
   } else {
 
@@ -1070,7 +1070,7 @@ extern "C" int eofunc_north(
 
     if (eval->type != NCOMP_DOUBLE) delete[] eval_d;
 
-    *sig = *ncomp_array_alloc((void*) sig_value, NCOMP_BOOL, eval->ndim, eval->shape);
+    *sig = ncomp_array_alloc((void*) sig_value, NCOMP_BOOL, eval->ndim, eval->shape);
   }
 
   int * N_attr = new int[1]{N};
@@ -1085,7 +1085,7 @@ extern "C" int eofunc_ts(
   const ncomp_array * x_in,
   const ncomp_array * evec_in,
   const ncomp_attributes * options_in,
-  ncomp_array * x_out,
+  ncomp_array ** x_out,
   ncomp_attributes * attrs_out)
 {
   int i_err {0};
@@ -1240,19 +1240,19 @@ extern "C" int eofunc_ts(
      delete[] evec_ts;
      delete[] evtsav;
 
-     *x_out = *ncomp_array_alloc(
+     *x_out = ncomp_array_alloc(
        (void *) revec_ts, NCOMP_FLOAT, 2, dsizes_evec_ts.get());
-     x_out->has_missing = x_in->has_missing;
-     x_out->msg.msg_float = missing_f_x;
+     (*x_out)->has_missing = x_in->has_missing;
+     (*x_out)->msg.msg_float = missing_f_x;
 
      tmp_attr_out.push_back(
        create_ncomp_single_attribute_from_1DArray((char *)"ts_mean", (void *) revtsav, NCOMP_FLOAT, neval)
      );
   } else { // at least one of the inputs is of type NCOMP_DOUBLE
-    *x_out = *ncomp_array_alloc(
+    *x_out = ncomp_array_alloc(
       (void *) evec_ts, NCOMP_DOUBLE, 2, dsizes_evec_ts.get());
-    x_out->has_missing = x_in->has_missing;
-    x_out->msg.msg_double = missing_d_x;
+    (*x_out)->has_missing = x_in->has_missing;
+    (*x_out)->msg.msg_double = missing_d_x;
 
     tmp_attr_out.push_back(
       create_ncomp_single_attribute_from_1DArray((char *)"ts_mean", (void *) evtsav, NCOMP_DOUBLE, neval)
@@ -1278,7 +1278,7 @@ extern "C" int eofunc_ts_n(
   const ncomp_array * ev_in,
   const ncomp_attributes * options_in,
   const int t_dim,
-  ncomp_array * x_out,
+  ncomp_array ** x_out,
   ncomp_attributes * attrs_out)
 {
   // Sanity Checking

--- a/src/wrappers/mocloops.cpp
+++ b/src/wrappers/mocloops.cpp
@@ -21,7 +21,7 @@ extern "C" void mocloops_(int *, int *, int *, int *, int *,
 extern "C" int moc_globe_atl( const ncomp_array * lat_aux_grid, const ncomp_array * a_wvel,
                               const ncomp_array * a_bolus, const ncomp_array * a_submeso,
                               const ncomp_array * tlat, const ncomp_array * rmlak,
-                              ncomp_array * tmp_out ){
+                              ncomp_array ** tmp_out ){
 
  /*
   * Various Variables
@@ -228,11 +228,11 @@ extern "C" int moc_globe_atl( const ncomp_array * lat_aux_grid, const ncomp_arra
                          (float *)tmp + 2 * kdepnyaux2);
 
       /* Populate output ncomp_array from tmp array */
-      *tmp_out = *ncomp_array_alloc((float *)tmp, NCOMP_FLOAT, ndims_tmp, dsizes_tmp);
+      *tmp_out = ncomp_array_alloc((float *)tmp, NCOMP_FLOAT, ndims_tmp, dsizes_tmp);
    }
    else
       /* Populate output ncomp_array from tmp array */
-      *tmp_out = *ncomp_array_alloc((double *)tmp, NCOMP_DOUBLE, ndims_tmp, dsizes_tmp);
+      *tmp_out = ncomp_array_alloc((double *)tmp, NCOMP_DOUBLE, ndims_tmp, dsizes_tmp);
 
   /* TO-DO: Check if has_missing and msg.msg_double needed
    tmp_out->has_missing = a_wvel->has_missing;

--- a/test/test_eofunc_01.c
+++ b/test/test_eofunc_01.c
@@ -30,15 +30,15 @@ int main(void) {
   ncomp_array* ncomp_x_in = ncomp_array_alloc((void*) x_in, NCOMP_DOUBLE, 3, dim_x);
   ncomp_x_in->has_missing = 1;
   ncomp_x_in->msg.msg_double = -999.0;
-  ncomp_array* ncomp_x_out = (ncomp_array*) malloc(sizeof(ncomp_array));
+  ncomp_array* ncomp_x_out;
   ncomp_attributes* attr = (ncomp_attributes*) malloc(sizeof(ncomp_attributes));
   int neval = 1;
 
   printf("Calling eofunc: ...\n");
 
-  int ierr = eofunc(ncomp_x_in, neval, options, ncomp_x_out, attr);
+  int ierr = eofunc(ncomp_x_in, neval, options, &ncomp_x_out, attr);
   // Alternatively you could call
-  // int ierr = eofunc(ncomp_x_in, neval, null, ncomp_x_out, attr);
+  // int ierr = eofunc(ncomp_x_in, neval, null, &ncomp_x_out, attr);
 
   if (ierr != 0) {
     printf("ierr: %d", ierr);

--- a/test/test_eofunc_02.c
+++ b/test/test_eofunc_02.c
@@ -35,12 +35,12 @@ int main(void) {
   ncomp_array* ncomp_x_in = ncomp_array_alloc((void*) x_in, NCOMP_DOUBLE, 3, dim_x);
   ncomp_x_in->has_missing = 1;
   ncomp_x_in->msg.msg_double = -999.0;
-  ncomp_array* ncomp_x_out = (ncomp_array*) malloc(sizeof(ncomp_array));
+  ncomp_array* ncomp_x_out;
   ncomp_attributes* attr = (ncomp_attributes*) malloc(sizeof(ncomp_attributes));
   int neval = 1;
 
   printf("Calling eofunc: ...\n");
-  int ierr = eofunc(ncomp_x_in, neval, options, ncomp_x_out, attr);
+  int ierr = eofunc(ncomp_x_in, neval, options, &ncomp_x_out, attr);
   if (ierr != 0) {
     printf("ierr: %d", ierr);
     return ierr;

--- a/test/test_eofunc_03.c
+++ b/test/test_eofunc_03.c
@@ -38,12 +38,12 @@ int main(void) {
   ncomp_array* ncomp_x_in = ncomp_array_alloc((void*) x_in, NCOMP_DOUBLE, 3, dim_x);
   ncomp_x_in->has_missing = 1;
   ncomp_x_in->msg.msg_double = -999.0;
-  ncomp_array* ncomp_x_out = (ncomp_array*) malloc(sizeof(ncomp_array));
+  ncomp_array* ncomp_x_out;
   ncomp_attributes* attr = (ncomp_attributes*) malloc(sizeof(ncomp_attributes));
   int neval = 1;
 
   printf("Calling eofunc: ...\n");
-  int ierr = eofunc(ncomp_x_in, neval, options, ncomp_x_out, attr);
+  int ierr = eofunc(ncomp_x_in, neval, options, &ncomp_x_out, attr);
   if (ierr != 0) {
     printf("ierr: %d", ierr);
     return ierr;

--- a/test/test_eofunc_04.c
+++ b/test/test_eofunc_04.c
@@ -41,12 +41,12 @@ int main(void) {
   ncomp_array* ncomp_x_in = ncomp_array_alloc((void*) x_in, NCOMP_DOUBLE, 3, dim_x);
   ncomp_x_in->has_missing = 1;
   ncomp_x_in->msg.msg_double = -999.0;
-  ncomp_array* ncomp_x_out = (ncomp_array*) malloc(sizeof(ncomp_array));
+  ncomp_array* ncomp_x_out;
   ncomp_attributes* attr = (ncomp_attributes*) malloc(sizeof(ncomp_attributes));
   int neval = 1;
 
   printf("Calling eofunc: ...\n");
-  int ierr = eofunc(ncomp_x_in, neval, options, ncomp_x_out, attr);
+  int ierr = eofunc(ncomp_x_in, neval, options, &ncomp_x_out, attr);
   if (ierr != 0) {
     printf("ierr: %d", ierr);
     return ierr;

--- a/test/test_eofunc_05.c
+++ b/test/test_eofunc_05.c
@@ -34,12 +34,12 @@ int main(void) {
   ncomp_array* ncomp_x_in = ncomp_array_alloc((void*) x_in, NCOMP_DOUBLE, 3, dim_x);
   ncomp_x_in->has_missing = 1;
   ncomp_x_in->msg.msg_double = -99.0;
-  ncomp_array* ncomp_x_out = (ncomp_array*) malloc(sizeof(ncomp_array));
+  ncomp_array* ncomp_x_out;
   ncomp_attributes* attr = (ncomp_attributes*) malloc(sizeof(ncomp_attributes));
   int neval = 1;
 
   printf("Calling eofunc: ...\n");
-  int ierr = eofunc(ncomp_x_in, neval, options, ncomp_x_out, attr);
+  int ierr = eofunc(ncomp_x_in, neval, options, &ncomp_x_out, attr);
   if (ierr != 0) {
     printf("ierr: %d", ierr);
     return ierr;

--- a/test/test_eofunc_06.c
+++ b/test/test_eofunc_06.c
@@ -34,12 +34,12 @@ int main(void) {
   ncomp_array* ncomp_x_in = ncomp_array_alloc((void*) x_in, NCOMP_FLOAT, 3, dim_x);
   ncomp_x_in->has_missing = 1;
   ncomp_x_in->msg.msg_float = -99.0;
-  ncomp_array* ncomp_x_out = (ncomp_array*) malloc(sizeof(ncomp_array));
+  ncomp_array* ncomp_x_out;
   ncomp_attributes* attr = (ncomp_attributes*) malloc(sizeof(ncomp_attributes));
   int neval = 1;
 
   printf("Calling eofunc: ...\n");
-  int ierr = eofunc(ncomp_x_in, neval, options, ncomp_x_out, attr);
+  int ierr = eofunc(ncomp_x_in, neval, options, &ncomp_x_out, attr);
   if (ierr != 0) {
     printf("ierr: %d", ierr);
     return ierr;

--- a/test/test_eofunc_n_01.c
+++ b/test/test_eofunc_n_01.c
@@ -30,13 +30,13 @@ int main(void) {
   ncomp_array* ncomp_x_in = ncomp_array_alloc((void*) x_in, NCOMP_DOUBLE, 3, dim_x);
   ncomp_x_in->has_missing = 1;
   ncomp_x_in->msg.msg_double = -999.0;
-  ncomp_array* ncomp_x_out = (ncomp_array*) malloc(sizeof(ncomp_array));
+  ncomp_array* ncomp_x_out;
   ncomp_attributes* attr = (ncomp_attributes*) malloc(sizeof(ncomp_attributes));
   int neval = 1;
 
   printf("Calling eofunc_n: ...\n");
   int t_dim = 1;
-  int ierr = eofunc_n(ncomp_x_in, neval, t_dim, options, ncomp_x_out, attr);
+  int ierr = eofunc_n(ncomp_x_in, neval, t_dim, options, &ncomp_x_out, attr);
 
   if (ierr != 0) {
     printf("ierr: %d", ierr);

--- a/test/test_eofunc_n_02.c
+++ b/test/test_eofunc_n_02.c
@@ -35,13 +35,13 @@ int main(void) {
   ncomp_array* ncomp_x_in = ncomp_array_alloc((void*) x_in, NCOMP_DOUBLE, 3, dim_x);
   ncomp_x_in->has_missing = 1;
   ncomp_x_in->msg.msg_double = -999.0;
-  ncomp_array* ncomp_x_out = (ncomp_array*) malloc(sizeof(ncomp_array));
+  ncomp_array* ncomp_x_out;
   ncomp_attributes* attr = (ncomp_attributes*) malloc(sizeof(ncomp_attributes));
   int neval = 1;
 
   printf("Calling eofunc_n: ...\n");
   int t_dim = 1;
-  int ierr = eofunc_n(ncomp_x_in, neval, t_dim, options, ncomp_x_out, attr);
+  int ierr = eofunc_n(ncomp_x_in, neval, t_dim, options, &ncomp_x_out, attr);
   if (ierr != 0) {
     printf("ierr: %d", ierr);
     return ierr;

--- a/test/test_eofunc_n_03.c
+++ b/test/test_eofunc_n_03.c
@@ -38,13 +38,13 @@ int main(void) {
   ncomp_array* ncomp_x_in = ncomp_array_alloc((void*) x_in, NCOMP_DOUBLE, 3, dim_x);
   ncomp_x_in->has_missing = 1;
   ncomp_x_in->msg.msg_double = -999.0;
-  ncomp_array* ncomp_x_out = (ncomp_array*) malloc(sizeof(ncomp_array));
+  ncomp_array* ncomp_x_out;
   ncomp_attributes* attr = (ncomp_attributes*) malloc(sizeof(ncomp_attributes));
   int neval = 1;
 
   printf("Calling eofunc_n: ...\n");
   int t_dim = 0;
-  int ierr = eofunc_n(ncomp_x_in, neval, t_dim, options, ncomp_x_out, attr);
+  int ierr = eofunc_n(ncomp_x_in, neval, t_dim, options, &ncomp_x_out, attr);
   if (ierr != 0) {
     printf("ierr: %d", ierr);
     return ierr;

--- a/test/test_eofunc_n_04.c
+++ b/test/test_eofunc_n_04.c
@@ -34,13 +34,13 @@ int main(void) {
   ncomp_array* ncomp_x_in = ncomp_array_alloc((void*) x_in, NCOMP_FLOAT, 3, dim_x);
   ncomp_x_in->has_missing = 1;
   ncomp_x_in->msg.msg_float = -99.0;
-  ncomp_array* ncomp_x_out = (ncomp_array*) malloc(sizeof(ncomp_array));
+  ncomp_array* ncomp_x_out;
   ncomp_attributes* attr = (ncomp_attributes*) malloc(sizeof(ncomp_attributes));
   int neval = 1;
 
   printf("Calling eofunc_n: ...\n");
   int t_dim = 1;
-  int ierr = eofunc_n(ncomp_x_in, neval, t_dim, options, ncomp_x_out, attr);
+  int ierr = eofunc_n(ncomp_x_in, neval, t_dim, options, &ncomp_x_out, attr);
   if (ierr != 0) {
     printf("ierr: %d", ierr);
     return ierr;

--- a/test/test_eofunc_n_05.c
+++ b/test/test_eofunc_n_05.c
@@ -34,13 +34,13 @@ int main(void) {
   ncomp_array* ncomp_x_in = ncomp_array_alloc((void*) x_in, NCOMP_DOUBLE, 3, dim_x);
   ncomp_x_in->has_missing = 1;
   ncomp_x_in->msg.msg_double = -99.0;
-  ncomp_array* ncomp_x_out = (ncomp_array*) malloc(sizeof(ncomp_array));
+  ncomp_array* ncomp_x_out;
   ncomp_attributes* attr = (ncomp_attributes*) malloc(sizeof(ncomp_attributes));
   int neval = 1;
 
   printf("Calling eofunc_n: ...\n");
   int t_dim = 1;
-  int ierr = eofunc_n(ncomp_x_in, neval, t_dim, options, ncomp_x_out, attr);
+  int ierr = eofunc_n(ncomp_x_in, neval, t_dim, options, &ncomp_x_out, attr);
   if (ierr != 0) {
     printf("ierr: %d", ierr);
     return ierr;

--- a/test/test_eofunc_n_06.c
+++ b/test/test_eofunc_n_06.c
@@ -30,13 +30,13 @@ int main(void) {
   ncomp_array* ncomp_x_in = ncomp_array_alloc((void*) x_in, NCOMP_DOUBLE, 3, dim_x);
   ncomp_x_in->has_missing = 0;
   ncomp_x_in->msg.msg_double = -999.0;
-  ncomp_array* ncomp_x_out = (ncomp_array*) malloc(sizeof(ncomp_array));
+  ncomp_array* ncomp_x_out;
   ncomp_attributes* attr = (ncomp_attributes*) malloc(sizeof(ncomp_attributes));
   int neval = 1;
 
   printf("Calling eofunc_n: ...\n");
   int t_dim = 1;
-  int ierr = eofunc_n(ncomp_x_in, neval, t_dim, options, ncomp_x_out, attr);
+  int ierr = eofunc_n(ncomp_x_in, neval, t_dim, options, &ncomp_x_out, attr);
 
   if (ierr != 0) {
     printf("ierr: %d", ierr);

--- a/test/test_eofunc_n_07.c
+++ b/test/test_eofunc_n_07.c
@@ -46,13 +46,13 @@ int main(void) {
   size_t dim_x[] = {nTime, nLat, nLon};
   ncomp_array* ncomp_x_in = ncomp_array_alloc((void*) data, NCOMP_DOUBLE, 3, dim_x);
   ncomp_x_in->has_missing = 0;
-  ncomp_array* ncomp_x_out = (ncomp_array*) malloc(sizeof(ncomp_array));
+  ncomp_array* ncomp_x_out;
   ncomp_attributes* attr = (ncomp_attributes*) malloc(sizeof(ncomp_attributes));
 
   printf("Calling eofunc_n: ...\n");
   int t_dim = 0;
   int neval = 5;
-  int ierr = eofunc_n(ncomp_x_in, neval, t_dim, NULL, ncomp_x_out, attr);
+  int ierr = eofunc_n(ncomp_x_in, neval, t_dim, NULL, &ncomp_x_out, attr);
 
   if (ierr != 0) {
     printf("ierr: %d", ierr);

--- a/test/test_eofunc_north_01.c
+++ b/test/test_eofunc_north_01.c
@@ -15,14 +15,14 @@ int main(void) {
   ncomp_eval_in->has_missing = 1;
   ncomp_eval_in->msg.msg_double = -99.0;
 
-  ncomp_array* ncomp_sig_out = (ncomp_array*) malloc(sizeof(ncomp_array));
+  ncomp_array* ncomp_sig_out;
   ncomp_attributes* attr = (ncomp_attributes*) malloc(sizeof(ncomp_attributes));
 
   int N = 320;
   int prinfo = 1;
 
   printf("Calling eofunc_north ... \n");
-  int ierr = eofunc_north(ncomp_eval_in, N, prinfo, ncomp_sig_out, attr);
+  int ierr = eofunc_north(ncomp_eval_in, N, prinfo, &ncomp_sig_out, attr);
 
   print_ncomp_array("ncomp_sig_out", ncomp_sig_out);
   print_ncomp_attributes(attr);

--- a/test/test_eofunc_north_02.c
+++ b/test/test_eofunc_north_02.c
@@ -15,14 +15,14 @@ int main(void) {
   ncomp_eval_in->has_missing = 1;
   ncomp_eval_in->msg.msg_double = -99.0;
 
-  ncomp_array* ncomp_sig_out = (ncomp_array*) malloc(sizeof(ncomp_array));
+  ncomp_array* ncomp_sig_out;
   ncomp_attributes* attr = (ncomp_attributes*) malloc(sizeof(ncomp_attributes));
 
   int N = 80;
   int prinfo = 1;
 
   printf("Calling eofunc_north ... \n");
-  int ierr = eofunc_north(ncomp_eval_in, N, prinfo, ncomp_sig_out, attr);
+  int ierr = eofunc_north(ncomp_eval_in, N, prinfo, &ncomp_sig_out, attr);
 
   print_ncomp_array("ncomp_sig_out", ncomp_sig_out);
   print_ncomp_attributes(attr);

--- a/test/test_eofunc_ts_01.c
+++ b/test/test_eofunc_ts_01.c
@@ -95,12 +95,12 @@ int main(void) {
   size_t dim_x[] = {nLat, nLon, nTime};
   ncomp_array* ncomp_x_in = ncomp_array_alloc((void*) data, NCOMP_DOUBLE, 3, dim_x);
   ncomp_x_in->has_missing = 0;
-  ncomp_array* ev = (ncomp_array*) malloc(sizeof(ncomp_array));
+  ncomp_array* ev;
   ncomp_attributes* ev_attr = (ncomp_attributes*) malloc(sizeof(ncomp_attributes));
 
   printf("Calling eofunc: ...\n");
   int neval = 5;
-  int ierr = eofunc(ncomp_x_in, neval, NULL, ev, ev_attr);
+  int ierr = eofunc(ncomp_x_in, neval, NULL, &ev, ev_attr);
 
   if (ierr != 0) {
     printf("ierr: %d\n", ierr);
@@ -227,9 +227,9 @@ int main(void) {
 
 
   printf("Calling eofunc_ts: ...\n");
-  ncomp_array* ev_ts = (ncomp_array*) malloc(sizeof(ncomp_array));
+  ncomp_array* ev_ts;
   ncomp_attributes* ev_ts_attr = (ncomp_attributes*) malloc(sizeof(ncomp_attributes));
-  ierr = eofunc_ts(ncomp_x_in, ev, NULL, ev_ts, ev_ts_attr);
+  ierr = eofunc_ts(ncomp_x_in, ev, NULL, &ev_ts, ev_ts_attr);
 
   if (ierr != 0) {
     printf("ierr: %d\n", ierr);

--- a/test/test_eofunc_ts_n_01.c
+++ b/test/test_eofunc_ts_n_01.c
@@ -95,13 +95,13 @@ int main(void) {
   size_t dim_x[] = {nTime, nLat, nLon};
   ncomp_array* ncomp_x_in = ncomp_array_alloc((void*) data, NCOMP_DOUBLE, 3, dim_x);
   ncomp_x_in->has_missing = 0;
-  ncomp_array* ev = (ncomp_array*) malloc(sizeof(ncomp_array));
+  ncomp_array* ev;
   ncomp_attributes* ev_attr = (ncomp_attributes*) malloc(sizeof(ncomp_attributes));
 
   printf("Calling eofunc_n: ...\n");
   int neval = 5;
   int t_dim = 0;
-  int ierr = eofunc_n(ncomp_x_in, neval, t_dim, NULL, ev, ev_attr);
+  int ierr = eofunc_n(ncomp_x_in, neval, t_dim, NULL, &ev, ev_attr);
 
   if (ierr != 0) {
     printf("ierr: %d\n", ierr);
@@ -228,9 +228,9 @@ int main(void) {
 
 
   printf("Calling eofunc_ts_n: ...\n");
-  ncomp_array* ev_ts = (ncomp_array*) malloc(sizeof(ncomp_array));
+  ncomp_array* ev_ts;
   ncomp_attributes* ev_ts_attr = (ncomp_attributes*) malloc(sizeof(ncomp_attributes));
-  ierr = eofunc_ts_n(ncomp_x_in, ev, NULL, t_dim, ev_ts, ev_ts_attr);
+  ierr = eofunc_ts_n(ncomp_x_in, ev, NULL, t_dim, &ev_ts, ev_ts_attr);
 
   if (ierr != 0) {
     printf("ierr: %d\n", ierr);

--- a/test/test_moc_globe_atl.c
+++ b/test/test_moc_globe_atl.c
@@ -62,12 +62,12 @@ int main(void) {
   ncomp_array* ncomp_rmlak = ncomp_array_alloc((void*) rmlak, NCOMP_INT, 3, dim_rmlak);
 
   // Allocating ,e,ory for output data
-  ncomp_array* ncomp_arr_out = (ncomp_array*) malloc(sizeof(ncomp_array));
+  ncomp_array* ncomp_arr_out = NULL;
 
   // Calling moc_globe_atl function
   printf("Calling moc_globe_atl: ...\n");
 
-  int ierr = moc_globe_atl(ncomp_lat_aux_grid, ncomp_a_wvel, ncomp_a_bolus, ncomp_a_submeso, ncomp_tlat, ncomp_rmlak, ncomp_arr_out);
+  int ierr = moc_globe_atl(ncomp_lat_aux_grid, ncomp_a_wvel, ncomp_a_bolus, ncomp_a_submeso, ncomp_tlat, ncomp_rmlak, &ncomp_arr_out);
 
   if (ierr != 0) {
     printf("ierr: %d", ierr);


### PR DESCRIPTION
Passing an ncomp_array* (to an existing allocated struct) as an argument to eofunc and then copying elements to it using "*ncomp_array_alloc()" results in a memory leak. A temporary struct is created inside ncomp_array_alloc(), and the elements of that struct (including pointers) are copied to *x_out, but the temporary struct itself is never actually freed:
```
int eofunc(..., ncomp_array* x_out, ...) {
    ...
    *x_out = *ncomp_array_alloc(...);
    ...
}
```

Instead, we should allocate an ncomp_array pointer outside of NComp and pass the address of the address of the pointer in:
```
ncomp_array* new_array = NULL;
eofunc(..., &new_array, ...);
```
```
int eofunc(..., ncomp_array** x_out, ...) {
    ...
    *x_out = ncomp_array_alloc(...);
    ...
}
```
